### PR TITLE
Add error if the elements of the order are not contained in the data

### DIFF
--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2347,6 +2347,11 @@ def barplot(
         legend=legend,
     )
 
+    if order is not None:
+        for element in order:
+            if element not in p.plot_data[p.orient].unique():
+                raise ValueError(f"Element {element} not in the data {p.plot_data[p.orient].unique()}.")
+
     if ax is None:
         ax = plt.gca()
 


### PR DESCRIPTION


If the elements of the order are not contained in the dataframe, the current behavior is to return an empty plot. This is problematic, because the source of the problem is difficult to find.